### PR TITLE
Switching colors between obits and recovers

### DIFF
--- a/docs/plot_aux.js
+++ b/docs/plot_aux.js
@@ -49,12 +49,12 @@ const colorMapping = {
         chartColor: '#08519c',
     },
     deaths: {
-        mapColor: d3.schemeGreens[9],
-        chartColor: '#006d2c',
-    },
-    recovered: {
         mapColor: d3.schemeReds[9],
         chartColor: '#a50f15',
+    },
+    recovered: {
+        mapColor: d3.schemeGreens[9],
+        chartColor: '#006d2c',
     },
 };
 


### PR DESCRIPTION
Green: is a color more associated with positive outcomes, the same happens for red with negative outcomes.
Here i change the deaths to red and recovers to green, so the people that are reading the graph can understand it easily